### PR TITLE
Use podman secret for database password

### DIFF
--- a/immich-database.container
+++ b/immich-database.container
@@ -6,13 +6,13 @@ Description=Immich Database
 Pod=immich.pod
 #you may want to take a look at https://github.com/immich-app/base-images/pkgs/container/postgres for alternative versions. DO NOT UPGRADE BETWEEN MAJOR VERSIONS!
 Image=ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
-Environment=POSTGRES_PASSWORD=${DB_PASSWORD}
 Environment=POSTGRES_USER=postgres
 Environment=POSTGRES_DB=immich
 Environment=POSTGRES_INITDB_ARGS=--data-checksums
 #Uncomment DB_STORAGE_TYPE=HDD if your database isn't stored on SSDs
 #Environment=DB_STORAGE_TYPE=HDD
 Volume=${DB_DATA_LOCATION}:/var/lib/postgresql/data:z
+Secret=imich_db_password,type=env,target=POSTGRES_PASSWORD
 
 [Service]
 TimeoutStartSec=900

--- a/immich-server.container
+++ b/immich-server.container
@@ -9,12 +9,12 @@ Image=ghcr.io/immich-app/immich-server:${IMMICH_VERSION}
 Volume=${UPLOAD_LOCATION}:/data:z
 Volume=/etc/localtime:/etc/localtime:ro
 Environment=TZ=${TZ}
-Environment=DB_PASSWORD=${DB_PASSWORD}
 Environment=DB_USERNAME=postgres
 Environment=DB_DATABASE_NAME=immich
 Environment=DB_HOSTNAME=localhost
 Environment=REDIS_HOSTNAME=localhost
 #AddDevice=/dev/dri
+Secret=imich_db_password,type=env,target=DB_PASSWORD
 
 [Service]
 TimeoutStartSec=900


### PR DESCRIPTION
What do you think about using [podman secrets](https://docs.podman.io/en/v4.6.0/markdown/options/secret.html) for the database password instead of having it plainly in the container files? It could be set using:

```shell
systemd-ask-password | podman secret create imich_db_password -
```
Here some sources for podman secrets I found useful.
   * [Using Secrets with Enviroments in Quadlets](https://www.reddit.com/r/podman/comments/1lp1vfr/using_secrets_with_enviroments_in_quadlets/)
   * [Podman secrets - How the hell does it work?](https://www.reddit.com/r/podman/comments/16onu8p/podman_secrets_how_the_hell_does_it_work/)